### PR TITLE
[IMP] add tag message in bumpversion to be able to do: git push --follow-tags

### DIFF
--- a/src/.bumpversion.cfg.jinja
+++ b/src/.bumpversion.cfg.jinja
@@ -2,6 +2,8 @@
 current_version = 1.0.0
 commit = True
 tag = True
+tag_name = {new_version}
+tag_message = {new_version}
 
 [bumpversion:file:.bumpversion.cfg]
 

--- a/src/README.md.jinja
+++ b/src/README.md.jinja
@@ -89,6 +89,6 @@ pytest --odoo-database=<dbname> odoo/addons
 1. First make sure you have been testing using the correct dependencies by
    running `pip-df sync` and checking there is no change in `requirements*.txt`.
 2. Update the version number using `bumpversion patch|minor|major` and push the tag
-   that bumpversion created with `git push && git push --tags`.
+   that bumpversion created with `git push --follow-tags`.
 3. The deploy to the test environment will be automatic, and GitLab will show buttons
    on the pipeline to deploy to other environments.


### PR DESCRIPTION
This is to be able to do 'git push --follow-tags' instead of 'git push && git push --tags' (one command instead of two)