### PR TITLE
[IMP] tag_prefix for pip-preserve-requirements

### DIFF
--- a/src/pyproject.toml.jinja
+++ b/src/pyproject.toml.jinja
@@ -77,7 +77,7 @@ requirements_files = [
 prefix = "container/requirements-group"
 
 [tool.pip-preserve-requirements]
-tag_prefix = "{{ project_trigram }}{{ odoo_series|replace('.', '') }}-"
+tag_prefix = "{{ odoo_series }}+{{ project_trigram }}+"
 match_any_tag = true
 
 [[tool.pip-preserve-requirements.vcs_vaults]]


### PR DESCRIPTION
The generated tags structure wasn't compatible with setuptools-scm used by for eg. openupgradelib, to determine version from tag.