### PR TITLE
Improve Dockerfile

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -83,7 +83,3 @@ repos:
       - id: isort
         name: isort except __init__.py
         exclude: /__init__\.py$
-  - repo: https://github.com/sbidoul/pip-split-requirements
-    rev: v0.7.0
-    hooks:
-      - id: pip-split-requirements

--- a/src/Dockerfile.jinja
+++ b/src/Dockerfile.jinja
@@ -61,20 +61,30 @@ RUN pip wheel --only-binary=:all: --no-deps --wheel-dir=/build-deps -r /build-de
 # --no-deps is to make sure we have pinned them all
 #
 
+FROM python:3.11-slim as split-requirements
+RUN pip install "pip-split-requirements>=0.7"
+WORKDIR /reqs/
+COPY requirements*.txt /reqs/
+RUN pip-split-requirements \
+    --group-spec="odoo:^(odoo|odoo-addons-enterprise)\s*@" \
+    --group-spec="odoo-addons:odoo-addon" \
+    --prefix="requirements-group" \
+    requirements.txt requirements-test.txt
+
 FROM build-deps as build-odoo
-COPY container/requirements-group-odoo.txt /build/reqs.txt
+COPY --from=split-requirements /reqs/requirements-group-odoo.txt /build/reqs.txt
 RUN --mount=type=ssh \
     --mount=type=cache,target=/root/.cache/pip \
     pip wheel --no-deps --wheel-dir=/build -r /build/reqs.txt
 
 FROM build-deps as build-odoo-addons
-COPY container/requirements-group-odoo-addons.txt /build/reqs.txt
+COPY --from=split-requirements /reqs/requirements-group-odoo-addons.txt /build/reqs.txt
 RUN --mount=type=ssh \
     --mount=type=cache,target=/root/.cache/pip \
     pip wheel --no-deps --wheel-dir=/build -r /build/reqs.txt
 
 FROM build-deps as build-other
-COPY container/requirements-group-other.txt /build/reqs.txt
+COPY --from=split-requirements /reqs/requirements-group-other.txt /build/reqs.txt
 RUN --mount=type=ssh \
     --mount=type=cache,target=/root/.cache/pip \
     pip wheel --no-deps --wheel-dir=/build -r /build/reqs.txt

--- a/src/Dockerfile.jinja
+++ b/src/Dockerfile.jinja
@@ -16,6 +16,7 @@ RUN set -e \
        postgresql-client \
        expect \
        gettext \
+       libxmlsec1-openssl \
   && apt -y clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -35,6 +36,7 @@ RUN set -e \
        python{{ python_version }}-dev \
        build-essential \
        libpq-dev \
+       pkg-config libxml2-dev libxmlsec1-dev \
   && apt -y clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/src/Dockerfile.jinja
+++ b/src/Dockerfile.jinja
@@ -99,10 +99,10 @@ FROM base as dependencies
 # Install python dependencies we built in the build stage.
 # Use --no-deps and --no-index to be sure to not download anything else.
 
-RUN --mount=type=bind,target=/build,source=/build,from=build-other \
+RUN --mount=type=bind,target=/build,source=/build,from=build-odoo \
   pip install --no-deps --no-index /build/*.whl
 
-RUN --mount=type=bind,target=/build,source=/build,from=build-odoo \
+RUN --mount=type=bind,target=/build,source=/build,from=build-other \
   pip install --no-deps --no-index /build/*.whl
 
 RUN --mount=type=bind,target=/build,source=/build,from=build-odoo-addons \

--- a/src/Dockerfile.jinja
+++ b/src/Dockerfile.jinja
@@ -20,7 +20,8 @@ RUN set -e \
   && rm -rf /var/lib/apt/lists/*
 
 #######################################################################################
-# build dependencies stage, where we download and install requirements-build.txt
+# builds-deps stage, where we download requirements-build.txt,
+# and install tools necessary to build source distributions.
 #
 
 FROM base as build-deps
@@ -43,38 +44,38 @@ RUN mkdir $HOME/.ssh \
   && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> $HOME/.ssh/config
 
 # Configure pip:
-# - no cache, to keep layers light
 # - use pep517 builds always (no setup.py bdist_wheel)
-ENV PIP_NO_CACHE_DIR=1 PIP_USE_PEP517=1
+# - constraint build depdendencies for better reproducibility
+ENV PIP_USE_PEP517=1 PIP_CONSTRAINTS=/build-deps/requirements-build.txt
 
 # Download build dependencies to /build-deps.
 # --only-binary=:all: is to avoid trying building build dependencies from source
 # --no-deps is to make sure we have pinned them all
 COPY requirements-build.txt /build-deps/
 RUN pip wheel --only-binary=:all: --no-deps --wheel-dir=/build-deps -r /build-deps/requirements-build.txt
-# pre-install build dependencies, so we can build without downloading them again
-RUN pip install --no-index --no-deps /build-deps/*.whl
 
 #######################################################################################
-# build stages, can run in parallel and be cached as independent layers.
-# --no-build-isolation is to use the build dependencies we have pre-installed above
+# build-* stages, can run in parallel and be cached as independent layers.
 # --no-deps is to make sure we have pinned them all
 #
 
 FROM build-deps as build-odoo
 COPY container/requirements-group-odoo.txt /build/reqs.txt
 RUN --mount=type=ssh \
-    pip wheel --no-build-isolation --no-deps --wheel-dir=/build -r /build/reqs.txt
+    --mount=type=cache,target=/root/.cache/pip \
+    pip wheel --no-deps --wheel-dir=/build -r /build/reqs.txt
 
 FROM build-deps as build-odoo-addons
 COPY container/requirements-group-odoo-addons.txt /build/reqs.txt
 RUN --mount=type=ssh \
-    pip wheel --no-build-isolation --no-deps --wheel-dir=/build -r /build/reqs.txt
+    --mount=type=cache,target=/root/.cache/pip \
+    pip wheel --no-deps --wheel-dir=/build -r /build/reqs.txt
 
 FROM build-deps as build-other
 COPY container/requirements-group-other.txt /build/reqs.txt
 RUN --mount=type=ssh \
-    pip wheel --no-build-isolation --no-deps --wheel-dir=/build -r /build/reqs.txt
+    --mount=type=cache,target=/root/.cache/pip \
+    pip wheel --no-deps --wheel-dir=/build -r /build/reqs.txt
 
 #######################################################################################
 # dependencies stage, installs wheels from build stages on top of other runtime deps.
@@ -109,4 +110,5 @@ FROM dependencies as runtime
 # have been installed before (i.e. they have been pinned in requirements.txt).
 COPY . /app
 RUN --mount=type=bind,target=/build-deps,source=/build-deps,from=build-deps \
+  --mount=type=cache,target=/root/.cache/pip \
   pip install --no-index --find-links /build-deps --editable /app

--- a/src/README.md.jinja
+++ b/src/README.md.jinja
@@ -18,7 +18,6 @@
 ### Development requirements
 
 - Install [pip-deepfreeze](https://pypi.python.org/pypi/pip-deepfreeze) with `pipx install pip-deepfreeze`
-- Install [pip-split-requirements](https://pypi.python.org/pypi/pip-split-requirements) with `pipx install pip-split-requirements`
 - Install [pip-preserve-requirements](https://pypi.python.org/pypi/pip-preserve-requirements) with `pipx install pip-preserve-requirements`
 - Install [bump2version](https://pypi.python.org/pypi/bump2version) with `pipx install bump2version`
 - [git-aggregator](https://pypi.python.org/pypi/git-aggregator) (`pipx install git-aggregator`) is also occasionally useful to

--- a/src/pyproject.toml.jinja
+++ b/src/pyproject.toml.jinja
@@ -62,19 +62,7 @@ addons_dirs = ["odoo/addons"]
 extras = "test,dev"
 post_sync_commands = [
   "pip-preserve-requirements requirements*.txt",
-  "pip-split-requirements",
 ]
-
-[tool.pip-split-requirements]
-group_specs = [
-  "odoo:^(odoo|odoo-addons-enterprise)\\s*@",
-  "odoo-addons:odoo-addon",
-]
-requirements_files = [
-  "requirements.txt",
-  "requirements-test.txt"
-]
-prefix = "container/requirements-group"
 
 [tool.pip-preserve-requirements]
 tag_prefix = "{{ odoo_series }}+{{ project_trigram }}+"

--- a/src/requirements-build.txt.in
+++ b/src/requirements-build.txt.in
@@ -5,3 +5,7 @@ hatch-odoo
 setuptools
 setuptools-odoo
 wheel
+# below is for xmlsec
+setuptools_scm[toml]>=3.4'
+pkgconfig>=1.5.1
+lxml>=3.8, !=4.7.0


### PR DESCRIPTION
- enable the pip cache in Dockerfile, for faster local builds
- use build constraints instead of build isolation
- add xmlsec build dependencies
- split the requirements in the Dockerfile instead of a pip-df post sync command (since this splitting is only necessary as a performance optimization for the Dockerfile): this avoid polluting the source with the requirement-groups*.txt

@acsone/acsone-odoo-team 
