### PR TITLE
ci: refine the --test-tags option

### DIFF
--- a/src/.gitlab-ci.yml.jinja
+++ b/src/.gitlab-ci.yml.jinja
@@ -62,7 +62,7 @@ test:
     - echo Installing project addons ${ADDONS_TEST}
     - unbuffer coverage run  /odoo/bin/odoo -c odoo-ci.cfg -d ${DB_NAME} --stop-after-init -i ${ADDONS_TEST} | /tmp/acsoo-env/bin/acsoo checklog
     - echo Testing project addons ${ADDONS_TEST}
-    - unbuffer coverage run /odoo/bin/odoo -c odoo-ci.cfg -d ${DB_NAME} --stop-after-init --test-tags ${ADDONS_TEST} --test-enable | /tmp/acsoo-env/bin/acsoo checklog
+    - unbuffer coverage run /odoo/bin/odoo -c odoo-ci.cfg -d ${DB_NAME} --stop-after-init --test-tags /${ADDONS_TEST//,/,\/} --test-enable | /tmp/acsoo-env/bin/acsoo checklog
     - if [ "${CI_COMMIT_REF_NAME}" = "master" ] ; then click-odoo-makepot -c odoo-ci.cfg -d ${DB_NAME} --msgmerge --addons-dir=odoo/addons ; fi
   after_script:
     - dropdb --if-exists ${DB_NAME}


### PR DESCRIPTION
Module tags must start with / (see odoo --help)

@acsone/acsone-team 