### PR TITLE
Remove useless isort config

### DIFF
--- a/src/.isort.cfg
+++ b/src/.isort.cfg
@@ -1,7 +1,0 @@
-[settings]
-profile=black
-multi_line_output=3
-known_odoo=odoo
-known_odoo_addons=odoo.addons
-sections=FUTURE,STDLIB,THIRDPARTY,ODOO,ODOO_ADDONS,FIRSTPARTY,LOCALFOLDER
-default_section=THIRDPARTY


### PR DESCRIPTION
We don't need this anymore since we use ruff.