### PR TITLE
ci: use buildkitd builder pool

### DIFF
--- a/src/.gitlab-ci.yml.jinja
+++ b/src/.gitlab-ci.yml.jinja
@@ -7,7 +7,7 @@ include:
     file: push-pot.yml
     ref: master
   - project: acsone/gitlab-ci-templates
-    file: build-publish-image-buildkit.yml
+    file: build-publish-image-buildkit-localpods.yml
     ref: master
   - project: acsone/gitlab-ci-templates
     file: python-coverage-report.yml
@@ -89,7 +89,7 @@ push-pot:
 # build container images
 
 .build-publish-image:
-  extends: .build-publish-image-buildkit
+  extends: .build-publish-image-buildkit-localpods
   {%- if odoo_enterprise %}
   variables:
     ACIT_SSH_KEY: $SSH_DEPLOY_KEY


### PR DESCRIPTION
The same builder with a local docker cache is preferred for all builds of a project.