### PR TITLE
[IMP] pyproject.toml: Ignore RUF012

### DIFF
--- a/src/pyproject.toml.jinja
+++ b/src/pyproject.toml.jinja
@@ -96,6 +96,7 @@ select = [
 ]
 ignore = [
   "E501", # line too long (covered by B950)
+  "RUF012", # Odoo commonly uses list class variables (_inherit, _sql_constraints,...)
 ]
 ignore-init-module-imports = true
 


### PR DESCRIPTION
Ruff doesn't like mutable class variables but Odoo uses lists for _inherit, _sql_constraints,...