### PR TITLE
[IMP] pyproject.toml.jinja: ignore ruff RUF012

### DIFF
--- a/src/pyproject.toml.jinja
+++ b/src/pyproject.toml.jinja
@@ -96,6 +96,7 @@ select = [
 ]
 ignore = [
   "E501", # line too long (covered by B950)
+  "RUF012", # Mutable class attributes should be annotated with typing.ClassVar
 ]
 ignore-init-module-imports = true
 


### PR DESCRIPTION
Mutable class attributes should be annotated with typing.ClassVar 
The problem is that it forces to transform some lists into tuples (in _sql_constrains, _inherits, ...) which goes against Odoo conventions