### PR TITLE
Improve xml autoformatter

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -21,15 +21,13 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.4
+    rev: v3.0.3
     hooks:
       - id: prettier
         name: prettier + plugin-xml
         additional_dependencies:
-          - "prettier@2.1.2"
-          - "@prettier/plugin-xml@0.12.0"
-        args:
-          - --plugin=@prettier/plugin-xml
+          - "prettier@3.0.3"
+          - "@prettier/plugin-xml@3.2.2"
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v8.34.0
     hooks:

--- a/src/.prettierrc.cjs
+++ b/src/.prettierrc.cjs
@@ -1,0 +1,12 @@
+/** @type {import('prettier').Config} */
+const config = {
+  plugins: [require.resolve("@prettier/plugin-xml")],
+  bracketSpacing: false,
+  printWidth: 88,
+  proseWrap: "always",
+  semi: true,
+  trailingComma: "es5",
+  xmlWhitespaceSensitivity: "preserve",
+};
+
+module.exports = config;

--- a/src/.prettierrc.yml
+++ b/src/.prettierrc.yml
@@ -1,9 +1,0 @@
-# Defaults for all prettier-supported languages.
-# Prettier will complete this with settings from .editorconfig file.
-bracketSpacing: false
-printWidth: 88
-proseWrap: always
-semi: true
-trailingComma: "es5"
-# can't use ignore because of https://github.com/prettier/plugin-xml/issues/138
-xmlWhitespaceSensitivity: "strict"


### PR DESCRIPTION
More information at https://github.com/prettier/plugin-xml/issues/478

Due to a weird interaction between pre-commit and the prettier plugin loading mechanism we need to change the prettier configuration format from yaml to cjs.