### PR TITLE
Declare minimum pip deepfreeze version

### DIFF
--- a/src/pyproject.toml.jinja
+++ b/src/pyproject.toml.jinja
@@ -62,6 +62,9 @@ addons_dirs = ["odoo/addons"]
 
 # pip-deepfreeze
 
+[tool.pip-deepfreeze]
+min_version = "2.0"
+
 [tool.pip-deepfreeze.sync]
 extras = "test,dev"
 post_sync_commands = [

--- a/src/pyproject.toml.jinja
+++ b/src/pyproject.toml.jinja
@@ -60,7 +60,9 @@ dependencies = [
 ]
 addons_dirs = ["odoo/addons"]
 
-# pip-deepfreeze
+#####################################################################################
+# pip-deepfreeze and post-sync commands
+#
 
 [tool.pip-deepfreeze]
 min_version = "2.0"
@@ -80,7 +82,9 @@ provider = "github.com"
 owner = "acsone"
 default = true
 
+#####################################################################################
 # ruff
+#
 
 [tool.ruff]
 target-version = "py{{ python_version | replace('.', '') }}"


### PR DESCRIPTION
This is supported by pip-deepfreeze 2.0+, and useful to ensure the team share pip-df features.