### PR TITLE
Enable kwkhtmltopdf in tests

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -35,6 +35,11 @@ python_version:
     - "3.10"
     - "3.11"
 
+kwkhtmltopdf_test_service:
+  type: bool
+  default: false
+  help: "Enable the kwkhtmltopdf service in CI tests."
+
 deploy_branch:
   type: bool
   default: true

--- a/src/.gitlab-ci.yml.jinja
+++ b/src/.gitlab-ci.yml.jinja
@@ -50,6 +50,13 @@ dev_status_check:
 
 test:
   extends: .test_common
+  {%- if kwkhtmltopdf_test_service %}
+    services:
+      - name: ghcr.io/acsone/kwkhtmltopdf:0.12.5-latest
+        alias: kwkhtmltopdf
+  variables:
+    KWKHTMLTOPDF_SERVER_URL: http://kwkhtmltopdf:8080
+  {%- endif %}
   tags:
     - postgres
   script:


### PR DESCRIPTION
Printing tests require HttpCase so CSS assets are available.