### PR TITLE
[FIX] gitlab-ci.yml: declaration of services - adjust indents

### DIFF
--- a/src/.gitlab-ci.yml.jinja
+++ b/src/.gitlab-ci.yml.jinja
@@ -51,9 +51,9 @@ dev_status_check:
 test:
   extends: .test_common
   {%- if kwkhtmltopdf_test_service %}
-    services:
-      - name: ghcr.io/acsone/kwkhtmltopdf:0.12.5-latest
-        alias: kwkhtmltopdf
+  services:
+    - name: ghcr.io/acsone/kwkhtmltopdf:0.12.5-latest
+      alias: kwkhtmltopdf
   variables:
     KWKHTMLTOPDF_SERVER_URL: http://kwkhtmltopdf:8080
   {%- endif %}


### PR DESCRIPTION
Small fix: I think that the declartion of services has been too much indented.