### PR TITLE
Fix fs_storage check_connection_method for readonly fsprod

### DIFF
--- a/src/odoo/addons/server_environment_files/test/test.conf
+++ b/src/odoo/addons/server_environment_files/test/test.conf
@@ -8,3 +8,6 @@ ir_attachment.location=db
 
 [fs_storage.fstest]
 use_as_default_for_attachments=True
+
+[fs_storage.fsprod]
+check_connection_method=False

--- a/src/odoo/addons/server_environment_files/uat/uat.conf
+++ b/src/odoo/addons/server_environment_files/uat/uat.conf
@@ -9,3 +9,5 @@ ir_attachment.location=db
 [fs_storage.fsuat]
 use_as_default_for_attachments=True
 
+[fs_storage.fsprod]
+check_connection_method=False


### PR DESCRIPTION
Default value for check_connection_method is marker_file, but this doens't work without write access.
Our test and uat env usually have read only access to the prod storage.
In our case, we don't really need to check the connection anyway.

See https://github.com/OCA/storage/pull/357
