### PR TITLE
[ADD] requirements-build: editables dependency

### DIFF
--- a/src/requirements-build.txt.in
+++ b/src/requirements-build.txt.in
@@ -1,5 +1,6 @@
 # build dependencies for building the project and all its dependencies
 # that need to be built from sources
+editables
 hatchling
 hatch-odoo
 setuptools


### PR DESCRIPTION
Since hatchling 1.22.4, editables is not a hard dependency, (it is provided by the get_requires_for_build_editable hook (https://github.com/pypa/hatch/pull/1255). We need to add it as a build dependency.