### PR TITLE
[FIX] rename the section of checklog-odoo

### DIFF
--- a/src/checklog-odoo.cfg
+++ b/src/checklog-odoo.cfg
@@ -1,4 +1,4 @@
 # Use regular expressions to ignore Odoo warnings in CI? Be as specific as possible.
-[checklog]
+[checklog-odoo]
 ignore=
   addons/base/models/ir_actions_report.py.*: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead


### PR DESCRIPTION
The previous name `checklog` is ignored and should be `checklog-odoo`