### PR TITLE
Stop using different deploy-test and deploy-prod branches

### DIFF
--- a/src/.gitlab-ci.yml.jinja
+++ b/src/.gitlab-ci.yml.jinja
@@ -167,7 +167,7 @@ build-prod-image:
 deploy-review-trigger:
   extends: .deploy-trigger
   variables:
-    DEPLOY_BRANCH: deploy-test
+    DEPLOY_BRANCH: deploy
     IMAGE_FLAVOR: /review
   needs:
     - job: build-review-image
@@ -180,7 +180,7 @@ deploy-review-trigger:
 deploy-test-trigger:
   extends: .deploy-trigger
   variables:
-    DEPLOY_BRANCH: deploy-test
+    DEPLOY_BRANCH: deploy
     IMAGE_FLAVOR: /test
   environment:
     name: test
@@ -192,7 +192,7 @@ deploy-test-trigger:
 deploy-uat-trigger:
   extends: .deploy-trigger
   variables:
-    DEPLOY_BRANCH: deploy-test
+    DEPLOY_BRANCH: deploy
     IMAGE_FLAVOR: /uat
   environment:
     name: uat
@@ -204,7 +204,7 @@ deploy-uat-trigger:
 deploy-prod-trigger:
   extends: .deploy-trigger
   variables:
-    DEPLOY_BRANCH: deploy-prod
+    DEPLOY_BRANCH: deploy
     IMAGE_FLAVOR: /prod
   environment:
     name: prod


### PR DESCRIPTION
This distinction did not show any practical benefit. When significant changes are needed in test and
we want to keep the prod deployment unchanged it is easier to create a dedicated branch for that.