### PR TITLE
Reduce reliance on SSH_DEPLOY_KEY

### DIFF
--- a/src/.gitlab-ci.yml.jinja
+++ b/src/.gitlab-ci.yml.jinja
@@ -97,10 +97,6 @@ push-pot:
 
 .build-publish-image:
   extends: .build-publish-image-buildkit-localpods
-  {%- if odoo_enterprise %}
-  variables:
-    ACIT_SSH_KEY: $SSH_DEPLOY_KEY
-  {%- endif %}
 
 build-dependencies-image:
   extends: .build-publish-image


### PR DESCRIPTION
To access source repos, we now have a group level key that is used by default.