### PR TITLE
[FIX] estlint.config.cjs: allow tag odoo-module for Odoo versions < 18.

### DIFF
--- a/src/eslint.config.cjs.jinja
+++ b/src/eslint.config.cjs.jinja
@@ -152,7 +152,11 @@ const config = [{
         strict: ["error", "function"],
         "use-isnan": "error",
 
+        {%- if odoo_series not in ("16.0", "17.0") %}
         "jsdoc/check-tag-names": "warn",
+        {%- else %}
+        "jsdoc/check-tag-names": ["warn", { "definedTags": ["odoo-module"] }],
+        {%- endif %}
         "jsdoc/check-types": "warn",
         "jsdoc/require-param-description": "off",
         "jsdoc/require-return": "off",


### PR DESCRIPTION
Avoid eslint raising ` Invalid JSDoc tag name "odoo-module"  jsdoc/check-tag-names` for tag `odoo-module` that is needed for Odoo versions <18.