### PR TITLE
Scope pip cache per base distro

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -40,6 +40,14 @@ python_version:
     - "3.11"
     - "3.12"
 
+distro:
+  type: str
+  default: noble
+  choices:
+    - noble
+    - jammy
+  help: "Base distro of the odoo-bedrock image"
+
 kwkhtmltopdf_test_service:
   type: bool
   default: false

--- a/src/Dockerfile.jinja
+++ b/src/Dockerfile.jinja
@@ -4,7 +4,7 @@
 # base stage, with the non-python runtime dependencies
 #
 
-FROM ghcr.io/acsone/odoo-bedrock:{{ odoo_series }}-py{{ python_version|replace('.', '') }}-jammy-latest as base
+FROM ghcr.io/acsone/odoo-bedrock:{{ odoo_series }}-py{{ python_version|replace('.', '') }}-{{ distro }}-latest as base
 
 # Install apt runtime dependencies.
 # - postgresql-client for comfort in the shell container and for db dump to work
@@ -76,19 +76,19 @@ RUN pip-split-requirements \
 FROM build-deps as build-odoo
 COPY --from=split-requirements /reqs/requirements-group-odoo.txt /build/reqs.txt
 RUN --mount=type=ssh \
-    --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cache/pip,id=pip-{{ distro }} \
     pip wheel --no-deps --wheel-dir=/build -r /build/reqs.txt
 
 FROM build-deps as build-odoo-addons
 COPY --from=split-requirements /reqs/requirements-group-odoo-addons.txt /build/reqs.txt
 RUN --mount=type=ssh \
-    --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cache/pip,id=pip-{{ distro }} \
     pip wheel --no-deps --wheel-dir=/build -r /build/reqs.txt
 
 FROM build-deps as build-other
 COPY --from=split-requirements /reqs/requirements-group-other.txt /build/reqs.txt
 RUN --mount=type=ssh \
-    --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cache/pip,id=pip-{{ distro }} \
     pip wheel --no-deps --wheel-dir=/build -r /build/reqs.txt
 
 #######################################################################################
@@ -125,5 +125,5 @@ FROM dependencies as runtime
 COPY . /app
 RUN python -m compileall /app/odoo /app/odoo_{{ project_name|lower|replace(' ', '_') }}
 RUN --mount=type=bind,target=/build-deps,source=/build-deps,from=build-deps \
-  --mount=type=cache,target=/root/.cache/pip \
+  --mount=type=cache,target=/root/.cache/pip,id=pip-{{ distro }} \
   pip install --no-index --find-links /build-deps --editable /app


### PR DESCRIPTION
This is important to have a different pip cache per distro, since, for instance, some C libraries we build declare their minium required GLIBC version.

Documentation for cache mounts: https://docs.docker.com/reference/dockerfile/#run---mounttypecache