### PR TITLE
[FIX] Barcode printing with python 3.12+

### DIFF
--- a/src/pyproject.toml.jinja
+++ b/src/pyproject.toml.jinja
@@ -76,6 +76,9 @@ dependencies = [
   "pypdf2<3",
   "werkzeug==3.0.*",
   {%- endif %}
+  {%- if python_version == "3.12" %}
+  "rl-renderPM",  # required for barcode printing in python 3.12+
+  {%- endif %}
 ]
 addons_dirs = ["odoo/addons"]
 


### PR DESCRIPTION
Fixes error when printing a report with barcode (ex. Picking Operations). See [this error](https://www.odoo.com/fr_FR/forum/aide-1/i-get-the-error-importerror-no-module-named-renderpm-156594).