### PR TITLE
[IMP] README.md.jinja - Adds the setup of Github CLI in the readme that is required before the odoo enterprise aggregation

### DIFF
--- a/src/README.md.jinja
+++ b/src/README.md.jinja
@@ -28,6 +28,7 @@
 ### Preliminary steps
 
 - Clone the repository
+- Set up Github CLI with `gh auth login` (It is mandatory because gitaggregate will fail the aggregation without returning an error)
 - Prepare the project-specific Odoo branch by running `gitaggregate -c gitaggregate.yaml -p`.
 - Pin the build dependencies using for CI by running `./sync-build.sh`
 


### PR DESCRIPTION
The odoo enterprise aggregation is using gh (Github CLI), but the readme doesn't explain how to setup the gh token. 

This modification adds a little description how to do it.