### PR TITLE
Improve entry point

### DIFF
--- a/src/container/entrypoint-dbbase.jinja
+++ b/src/container/entrypoint-dbbase.jinja
@@ -48,14 +48,14 @@ if db_name:
         check_call(
             [
                 "click-odoo-initdb",
-                "--unless-exists",
+                # initialize existing empty db created by copydb
+                "--unless-initialized",
+                # cache is not very useful in this context
+                "--no-cache",
+                # store attachments in db until fs_attachment takes over
+                "--attachments-in-db"
                 "-n",
                 database,
-                # Don't use --no-cache so attachments created before fs_attachment
-                # is configured are stored in the database instead of the filesystem
-                # (where the would be lost upon restart of the container).
-                # https://github.com/acsone/click-odoo-contrib/issues/146
-                # "--no-cache",
                 "-m",
                 "{{ project_trigram }}_fs_attachment,server_environment_ir_config_parameter",
             ]

--- a/src/pyproject.toml.jinja
+++ b/src/pyproject.toml.jinja
@@ -42,7 +42,7 @@ packages = ["odoo", "odoo_{{ project_name|lower|replace(' ', '_') }}"]
 odoo_version_override = "{{ odoo_series }}"
 # Add dependencies that are not declared in Odoo addons manifests.
 dependencies = [
-  "click-odoo-contrib",
+  "click-odoo-contrib>=1.22",
   {%- if odoo_enterprise %}
   # Odoo enterprise addons
   "odoo-addons-enterprise",


### PR DESCRIPTION
Take advantage of the new click-odoo-initdb features to

- work when the odoo db is pre-created and empty (which is the case with cnpg).
- store attachments in db while disabling the cache