### PR TITLE
[FIX] Dockerfile.jinja - It seems that with the Odoo bedrock 3.13 the directory .ssh already exist, causing an error when its try to create it

### DIFF
--- a/src/Dockerfile.jinja
+++ b/src/Dockerfile.jinja
@@ -43,7 +43,7 @@ RUN set -e \
   && rm -rf /var/lib/apt/lists/*
 
 # Configure ssh.
-RUN mkdir $HOME/.ssh \
+RUN mkdir -p $HOME/.ssh \
  && ssh-keyscan github.com >> $HOME/.ssh/known_hosts \
  && ssh-keyscan gitlab.acsone.eu >> $HOME/.ssh/known_hosts
 


### PR DESCRIPTION
During the build dependencies stage and more precisely during the SSH Configuration, we try to create the directory /root/.ssh.
But with the odoo-bedrock:19.0-py313 It seems that the folder already exists, so i add a little option to the mkdir to avoid triggering an error if the folder exists.