### PR TITLE
Add libmagic support for better mimetype detection

### DIFF
--- a/src/Dockerfile.jinja
+++ b/src/Dockerfile.jinja
@@ -18,6 +18,7 @@ RUN set -e \
        gettext \
        libxmlsec1-openssl \
        libcairo2 \
+       libmagic1 \
   && apt -y clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/src/pyproject.toml.jinja
+++ b/src/pyproject.toml.jinja
@@ -56,6 +56,7 @@ dependencies = [
   "num2words",
   "pdfminer",
   "phonenumbers",
+  "python-magic",
   "python-slugify[unidecode]",
   "reportlab[pycairo] >=4.0.4",
   {%- if odoo_series == "18.0" %}


### PR DESCRIPTION
This is an optional dependency that improves `odoo.tools.mimetypes.guess_mimetype`.
