### PR TITLE
[IMP] requirements-build.txt.in: add whool in build requirements

### DIFF
--- a/src/requirements-build.txt.in
+++ b/src/requirements-build.txt.in
@@ -5,6 +5,7 @@ hatchling
 hatch-odoo
 setuptools
 setuptools-odoo
+whool
 wheel
 # below is for xmlsec
 setuptools_scm[toml]>=3.4


### PR DESCRIPTION
## Context

Whool is now widely used as it tends to replace setuptools-odoo.

Whool should be in build dependencies