### PR TITLE
[IMP] requirements-build: remove setuptools-odoo for odoo < 17

### DIFF
--- a/src/requirements-build.txt.in
+++ b/src/requirements-build.txt.in
@@ -4,7 +4,9 @@ editables
 hatchling
 hatch-odoo
 setuptools
+{%- if odoo_series < "17.0" %}
 setuptools-odoo
+{%- endif %}
 whool
 wheel
 # below is for xmlsec


### PR DESCRIPTION
As explained in Setuptool-odoo's [readme](https://github.com/acsone/setuptools-odoo/blob/master/README.rst), it is progressively being deprecated:

> Please consider using [whool](https://github.com/sbidoul/whool) for packaging individual Odoo addons, and [hatch-odoo](https://github.com/acsone/hatch-odoo) to build complete projects that include Odoo addons.