### PR TITLE
[UPD] Update coverage config: update `omit` section of `.coveragerc`

### DIFF
--- a/src/.coveragerc
+++ b/src/.coveragerc
@@ -7,9 +7,16 @@ parallel = True
 
 [report]
 omit =
+    */scenario/*
     */scenarios/*
+    */test/*
+    */tests/*
     */lib/*
-    */__manifest__.py
+    *_example/*
+    *__init__.py
+    *__manifest__.py
+    *hooks.py
+    *_parser.py
 
 # Regexes for lines to exclude from consideration
 exclude_lines =


### PR DESCRIPTION
IMO we shouldn't take somes files in the coverage percentage to let this percentage more representative.